### PR TITLE
docs(contribute): replace Azure DevOps references with GitHub equivalents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,11 @@ By participating, you are expected to uphold this code. Please see the [Code of 
 
 > If you want to ask a question, we assume that you have read the available [Documentation](./docs/README.md).
 
-Before you ask a question, it is best to search for existing [Issues](https://dev.azure.com/ai-at-the-edge-flagship-accelerator/IaC%20for%20the%20Edge/_queries/query/a8d3e164-fe33-43a9-83c3-b60c4c51934d/) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/microsoft/edge-ai/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-- Open an [Issue](https://dev.azure.com/ai-at-the-edge-flagship-accelerator/IaC%20for%20the%20Edge/_workitems/create/Issue).
+- Open an [Issue](https://github.com/microsoft/edge-ai/issues/new/choose).
 - Provide as much context as you can about what you're running into.
 - Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
 
@@ -63,7 +63,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 - Make sure that you are using the latest version of the project.
 - Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](./docs/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://dev.azure.com/ai-at-the-edge-flagship-accelerator/IaC%20for%20the%20Edge/_queries/query/a8d3e164-fe33-43a9-83c3-b60c4c51934d/).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/microsoft/edge-ai/issues?q=label%3Abug).
 - Also make sure to search the internet (including internal and external Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
   - Stack trace (Traceback)
@@ -78,7 +78,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use Azure DevOps issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](https://dev.azure.com/ai-at-the-edge-flagship-accelerator/IaC%20for%20the%20Edge/_workitems/create/Issue). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a "bug" yet and not to label the issue as a "bug.")
+- Open an [Issue](https://github.com/microsoft/edge-ai/issues/new?template=bug_report.md). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a "bug" yet and not to label the issue as a "bug.")
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
@@ -97,12 +97,12 @@ This section guides you through submitting an enhancement suggestion for CONTRIB
 
 - Make sure that you are using the latest version.
 - Read the [documentation](./docs/README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
-- Perform a [search](https://dev.azure.com/ai-at-the-edge-flagship-accelerator/IaC%20for%20the%20Edge/_workitems/) to see if the enhancement has already been suggested. If it has, add a comment to the existing workitem instead of opening a new one.
+- Perform a [search](https://github.com/microsoft/edge-ai/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing workitem instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library or a sub-project.
 
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [Azure DevOps Features](https://dev.azure.com/ai-at-the-edge-flagship-accelerator/IaC%20for%20the%20Edge/_backlogs/backlog/IaC%20for%20the%20Edge%20Team/Features).
+Enhancement suggestions are tracked as [GitHub Issues](https://github.com/microsoft/edge-ai/issues/new?template=feature_request.md) labeled `enhancement`.
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
@@ -115,7 +115,7 @@ Enhancement suggestions are tracked as [Azure DevOps Features](https://dev.azure
 When contributing code to the project, please consider the following guidance:
 
 - Assign a workitem to yourself before beginning any effort, and set the item's status field accordingly.
-- If a work item for your contribution does not exist, [please file an issue](https://dev.azure.com/ai-at-the-edge-flagship-accelerator/edge-ai/_workitems/create/Issue) first to engage the project's PO, TPM, or Tech Lead for guidance.
+- If a work item for your contribution does not exist, [please file an issue](https://github.com/microsoft/edge-ai/issues/new/choose) first to engage the project's PO, TPM, or Tech Lead for guidance.
 - Commits (or at least one in a commit chain) should reference a User Story or Task item from the backlog for traceability.
 - When creating a PR, ensure descriptions use [Azure DevOps notation to close associated work items](https://learn.microsoft.com/azure/devops/repos/git/resolution-mentions?view=azure-devops).
 - All code PRs destined for the `main` branch will be reviewed by pre-determined reviewer groups that are automatically added to each PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 > You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be filed using [Report It Now](https://aka.ms/reportitnow).
 
-We use Azure DevOps issues to track bugs and errors. If you run into an issue with the project:
+We use GitHub Issues to track bugs and errors. If you run into an issue with the project:
 
 - Open an [Issue](https://github.com/microsoft/edge-ai/issues/new?template=bug_report.md). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a "bug" yet and not to label the issue as a "bug.")
 - Explain the behavior you would expect and the actual behavior.
@@ -114,10 +114,10 @@ Enhancement suggestions are tracked as [GitHub Issues](https://github.com/micros
 
 When contributing code to the project, please consider the following guidance:
 
-- Assign a workitem to yourself before beginning any effort, and set the item's status field accordingly.
+- Assign the GitHub Issue to yourself before beginning any effort, and set the item's status field accordingly.
 - If a work item for your contribution does not exist, [please file an issue](https://github.com/microsoft/edge-ai/issues/new/choose) first to engage the project's PO, TPM, or Tech Lead for guidance.
-- Commits (or at least one in a commit chain) should reference a User Story or Task item from the backlog for traceability.
-- When creating a PR, ensure descriptions use [Azure DevOps notation to close associated work items](https://learn.microsoft.com/azure/devops/repos/git/resolution-mentions?view=azure-devops).
+- Commits (or at least one in a commit chain) should reference the GitHub Issue using `Fixes #123` or `Closes #123` for traceability.
+- When creating a PR, ensure descriptions use [GitHub closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
 - All code PRs destined for the `main` branch will be reviewed by pre-determined reviewer groups that are automatically added to each PR.
 
 This project also includes a Dev Container for development work, and using that dev container is preferred, to ensure you are using the same toolchains and tool versions as other contributors. You can read more about the Dev Container in its [ReadMe](./.devcontainer/README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 - Make sure that you are using the latest version of the project.
 - Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](./docs/README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/microsoft/edge-ai/issues?q=label%3Abug).
-- Also make sure to search the internet (including internal and external Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
+- Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
   - Stack trace (Traceback)
   - OS, Platform and Version (Windows, Linux, macOS, x86, ARM)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ Enhancement suggestions are tracked as [GitHub Issues](https://github.com/micros
 When contributing code to the project, please consider the following guidance:
 
 - Assign the GitHub Issue to yourself before beginning any effort, and set the item's status field accordingly.
-- If a work item for your contribution does not exist, [please file an issue](https://github.com/microsoft/edge-ai/issues/new/choose) first to engage the project's PO, TPM, or Tech Lead for guidance.
+- If an issue for your contribution does not exist, [please create one](https://github.com/microsoft/edge-ai/issues/new/choose) first to engage the project's PO, TPM, or Tech Lead for guidance.
 - Commits (or at least one in a commit chain) should reference the GitHub Issue using `Fixes #123` or `Closes #123` for traceability.
 - When creating a PR, ensure descriptions use [GitHub closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
 - All code PRs destined for the `main` branch will be reviewed by pre-determined reviewer groups that are automatically added to each PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ If you see issues with the documentation, please follow the [your first code con
 
 This project uses MegaLinter with numerous custom configured linters. These linters can be run locally to ensure that code reads the same across the project.
 
-For detailed information about our MegaLinter configuration, integration with our CI/CD pipeline, and available linters, please refer to our [MegaLinter documentation](./docs/build-cicd/pipelines/azure-devops/templates/megalinter-template.md).
+For detailed information about our MegaLinter configuration, integration with our CI/CD pipeline, and available linters, please refer to our [MegaLinter documentation](./docs/build-cicd/azure-pipelines/templates/megalinter-template.md).
 
 ### Development Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ If you see issues with the documentation, please follow the [your first code con
 
 This project uses MegaLinter with numerous custom configured linters. These linters can be run locally to ensure that code reads the same across the project.
 
-For detailed information about our MegaLinter configuration, integration with our CI/CD pipeline, and available linters, please refer to our [MegaLinter documentation](./docs/build-cicd/azure-pipelines/templates/megalinter-template.md).
+For detailed information about our MegaLinter configuration, integration with our CI/CD pipeline, and available linters, please refer to our [MegaLinter documentation](./docs/build-cicd/github-actions/templates/megalinter.md).
 
 ### Development Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ Refer to the [DevContainer README](./.devcontainer/README.md) for detailed infor
 
 ### Coding Conventions
 
-For detailed information about our coding standards, please refer to the [Coding Conventions](./docs/coding-conventions.md) document, which includes:
+For detailed information about our coding standards, please refer to the [Coding Conventions](./docs/contributing/coding-conventions.md) document, which includes:
 
 - Infrastructure as Code standards (Terraform and Bicep)
 - Git workflow practices including Conventional Commits


### PR DESCRIPTION
# Pull Request

## Description
I replaced Azure DevOps organization URLs with GitHub-native equivalents, fixed broken links for MegaLinter and Coding Conventions, rewrote ADO workflow language for GitHub-native workflows and removed the "internal Stack Overflow" reference.

## Related Issue
Closes #194 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Blueprint modification or addition
- [ ] Component modification or addition
- [x] Documentation update
- [ ] CI/CD pipeline change
- [ ] Other (please describe):

## Testing Performed
- [ ] Terraform plan/apply
- [ ] Blueprint deployment test
- [ ] Unit tests
- [ ] Integration tests
- [ ] Bug fix includes regression test (see [Test Policy](docs/contributing/testing-validation.md))
- [x] Manual validation
- [ ] Other:
