### PR TITLE
fix(ai-edge-inference): bump notify 7 to 8 (partial RUSTSEC-2024-0384)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,22 @@
+# OSV-Scanner configuration consumed by OpenSSF Scorecard's Vulnerabilities check
+# and direct osv-scanner runs. Mirrors .github/audit.toml suppressions.
+#
+# Each entry below is an unmaintained or unsound transitive that cannot be
+# dropped without an upstream release of a direct dependency. Re-evaluate
+# whenever direct dependencies are bumped.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0384"
+reason = "instant: unmaintained; transitive via notify-types <- notify <- notify-debouncer-full <- azure_iot_operations_mqtt 0.9.0. Resolves when the AIO MQTT SDK upgrades to notify v8+."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0436"
+reason = "paste: unmaintained; transitive via gemm/pulp <- candle-core 0.9.2 (ONNX inference stack). Resolves when the candle stack drops paste."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0134"
+reason = "rustls-pemfile 1.x: unmaintained; transitive via hyper-rustls. Resolves when upstream pulls rustls-pemfile 2.x."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0097"
+reason = "rand: unsoundness with custom logger; awaiting upstream release."

--- a/src/500-application/507-ai-inference/services/ai-edge-inference/Cargo.lock
+++ b/src/500-application/507-ai-inference/services/ai-edge-inference/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
  "image",
  "lazy_static",
  "mockall",
- "notify",
+ "notify 8.2.0",
  "once_cell",
  "parking_lot",
  "prometheus",
@@ -245,7 +245,7 @@ dependencies = [
  "derive_builder",
  "futures",
  "log",
- "notify",
+ "notify 7.0.0",
  "notify-debouncer-full",
  "openssl",
  "rand 0.8.6",
@@ -2009,6 +2009,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
 name = "inotify-sys"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,14 +2430,32 @@ dependencies = [
  "bitflags 2.11.1",
  "filetime",
  "fsevent-sys",
- "inotify",
+ "inotify 0.10.2",
  "kqueue",
  "libc",
  "log",
  "mio",
- "notify-types",
+ "notify-types 1.0.1",
  "walkdir",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify 0.11.1",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types 2.1.0",
+ "walkdir",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2437,8 +2466,8 @@ checksum = "9dcf855483228259b2353f89e99df35fc639b2b2510d1166e4858e3f67ec1afb"
 dependencies = [
  "file-id",
  "log",
- "notify",
- "notify-types",
+ "notify 7.0.0",
+ "notify-types 1.0.1",
  "walkdir",
 ]
 
@@ -2449,6 +2478,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]

--- a/src/500-application/507-ai-inference/services/ai-edge-inference/Cargo.toml
+++ b/src/500-application/507-ai-inference/services/ai-edge-inference/Cargo.toml
@@ -70,7 +70,7 @@ governor = "0.8"
 
 # File system operations
 walkdir = "2.4"
-notify = "7.0"
+notify = "8"
 
 [dev-dependencies]
 serial_test = "3.0"


### PR DESCRIPTION
## Summary

Partial remediation of **RUSTSEC-2024-0384** (instant unmaintained) by bumping 
otify from v7 to v8 in the  + "i-edge-mqtt-publisher" +  crate. The v8 line of  + "
otify" +  drops the  + "instant" +  dependency.

## Scope

-  + "src/500-application/507-ai-inference/services/ai-edge-inference/Cargo.toml" +  — bump  + "
otify" +  dep to  + "\"8\"" + .
-  + "src/500-application/507-ai-inference/services/ai-edge-inference/Cargo.lock" +  — regenerated;  + "
otify v8.2.0" +  resolved.
-  + "osv-scanner.toml" +  — adopt OSV-Scanner suppression file mirroring  + ".github/audit.toml" +  for OpenSSF Scorecard's Vulnerabilities check (includes documented rationale for each ignored advisory).

## Why partial?

 + "instant" +  still appears transitively via  + "zure_iot_operations_mqtt 0.9.0 -> 
otify-debouncer-full 0.4.0 -> 
otify-types 1.0.1 -> instant" + . Full remediation requires the Azure IoT Operations Rust SDK to upgrade to  + "
otify v8+" + . This PR removes one of two consumers of  + "
otify v7" +  in the workspace.

## Related

- **RUSTSEC-2024-0384** —  + "instant" +  unmaintained (partially addressed)
- **RUSTSEC-2024-0436** —  + "paste" +  unmaintained (transitive via  + "candle-core" + ; tracked in  + "osv-scanner.toml" + )
- Follow-up: file issue against Azure IoT Operations Rust SDK to bump  + "
otify" + .

## Validation

-  + "cargo update" +  succeeded; lockfile clean.
- Source grep confirmed no  + "
otify" +  v7→v8 API breakage in  + "i-edge-mqtt-publisher" +  call-sites.