### PR TITLE
fix(docs): remove ignoreDeprecations in tsconfig.json

### DIFF
--- a/docs/docusaurus/tsconfig.json
+++ b/docs/docusaurus/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "ignoreDeprecations": "6.0"
-  }
+  "compilerOptions": {}
 }

--- a/docs/docusaurus/tsconfig.json
+++ b/docs/docusaurus/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "6.0"
   }
 }


### PR DESCRIPTION
## Description

Fixes a TypeScript typecheck CI failure caused by a TS 5.9 catch-22 with `baseUrl` deprecation:

- TS 5.9 deprecates `baseUrl` and instructs setting `ignoreDeprecations: "6.0"` (TS5101)
- However, `"6.0"` is only a valid value in TypeScript 6.x — TS 5.x rejects it with TS5103
- `ignoreDeprecations: "5.0"` still triggers TS5101 in TS 5.9, making both workarounds invalid

The root fix is removing `baseUrl: "."` entirely. No source files in `docs/docusaurus/src/` use root-relative imports that rely on `baseUrl`, making this safe.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD pipeline change

## Implementation Details

Removed `baseUrl` and `ignoreDeprecations` from `docs/docusaurus/tsconfig.json`. The locked TypeScript version is `5.9.3` (via `package-lock.json`), which introduced this breaking deprecation behavior.

## Testing Performed

- [x] Manual validation — confirmed no root-relative imports in `docs/docusaurus/src/`
- [x] TypeScript typecheck (`tsc --noEmit`) passes after removing `baseUrl`

## Validation Steps

1. Run `npm run typecheck` from `docs/docusaurus/` — expect clean output with no TS5101 or TS5103 errors.

## Checklist

- [x] All new and existing tests passed
- [x] Lint checks pass (run applicable linters for changed file types)
- [x] I have checked for any sensitive data/tokens that should not be committed

## Security Review

- [x] No credentials, secrets, or tokens are hardcoded or logged
- [x] No new network exposure or public endpoints introduced without justification