### PR TITLE
fix(ci): sign release tags and pin repo context

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -85,7 +85,10 @@ jobs:
           TAG: ${{ steps.release.outputs.tag_name }}
         run: |
           set -euo pipefail
-          git tag -v "${TAG}"
+          gitsign verify-tag \
+            --certificate-identity 'https://github.com/microsoft/edge-ai/.github/workflows/release-please.yml@refs/heads/main' \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+            "${TAG}"
 
   generate-dependency-sbom:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,24 +40,52 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: release-please-manifest.json
+          skip-github-pull-request: ${{ github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main)') }}
 
-      - name: Create git tag for draft release
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: steps.release.outputs.release_created == 'true'
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Create signed git tag for draft release
         if: steps.release.outputs.release_created == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.release.outputs.tag_name }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          if ! gh api "/repos/$REPO/git/refs/tags/$TAG" --silent 2>/dev/null; then
-            gh api "/repos/$REPO/git/refs" \
-              -f "ref=refs/tags/$TAG" \
-              -f "sha=$SHA"
-            echo "Created git tag $TAG -> $SHA"
-          else
-            echo "Git tag $TAG already exists"
+
+          git config --global gpg.format x509
+          git config --global gpg.x509.program gitsign
+          git config --global tag.gpgSign true
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git fetch --tags --force
+
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            tag_type=$(git cat-file -t "refs/tags/${TAG}")
+            if [[ "${tag_type}" != "tag" ]]; then
+              echo "Expected annotated tag object for ${TAG}, found ${tag_type}." >&2
+              exit 1
+            fi
+            echo "Git tag ${TAG} already exists"
+            exit 0
           fi
+
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git tag -s "${TAG}" "${GITHUB_SHA}" -m "Release ${TAG}"
+          git push origin "refs/tags/${TAG}"
+          echo "Created signed git tag ${TAG} -> ${GITHUB_SHA}"
+
+      - name: Verify signed git tag
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          git tag -v "${TAG}"
 
   generate-dependency-sbom:
     needs: release-please
@@ -106,7 +134,9 @@ jobs:
         run: |
           set -euo pipefail
           gh release upload "${{ needs.release-please.outputs.tag_name }}" \
-            dep-sbom.spdx.json dep-sbom.spdx.json.intoto.jsonl --clobber
+            dep-sbom.spdx.json dep-sbom.spdx.json.intoto.jsonl \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber
 
   attest-release:
     needs: release-please
@@ -151,6 +181,7 @@ jobs:
           gh release upload "${TAG}" \
             "release-artifacts/source-${TAG}.tar.gz" \
             "release-artifacts/source-${TAG}.tar.gz.intoto.jsonl" \
+            --repo "${GITHUB_REPOSITORY}" \
             --clobber
 
   sbom-diff:
@@ -172,10 +203,12 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p previous-sbom
-          prev=$(gh release list --limit 10 --json tagName \
-            --jq "[.[] | select(.tagName != \"${TAG}\")][0].tagName // empty")
+          prev=$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 10 \
+            --json tagName,isDraft \
+            --jq '[.[] | select(.tagName != env.TAG and .isDraft == false)] | first | .tagName // empty')
           if [[ -n "${prev}" ]]; then
-            gh release download "${prev}" --pattern 'dep-sbom.spdx.json' \
+            gh release download "${prev}" --repo "${GITHUB_REPOSITORY}" \
+              --pattern 'dep-sbom.spdx.json' \
               --dir previous-sbom || true
           fi
 
@@ -233,9 +266,11 @@ jobs:
             cat sbom-diff/sbom-diff.txt
             printf '```\n'
           } > notes-appendix.md
-          gh release view "${TAG}" --json body --jq .body > existing-body.md || true
+          gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+            --json body --jq .body > existing-body.md || true
           cat existing-body.md notes-appendix.md > merged-body.md
-          gh release edit "${TAG}" --notes-file merged-body.md
+          gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+            --notes-file merged-body.md
 
   publish-release:
     needs: [release-please, attest-release, sbom-diff, append-verification-notes]
@@ -250,7 +285,7 @@ jobs:
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
           set -euo pipefail
-          gh release edit "${TAG}" --draft=false
+          gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
 
   close-milestone:
     needs: [release-please, publish-release]

--- a/.github/workflows/verify-tag-signature.yml
+++ b/.github/workflows/verify-tag-signature.yml
@@ -41,6 +41,11 @@ jobs:
             echo "Tag ${TAG_NAME} not found in repository." >&2
             exit 1
           fi
+          tag_type=$(git cat-file -t "refs/tags/${TAG_NAME}")
+          if [[ "${tag_type}" != "tag" ]]; then
+            echo "Expected annotated tag object for ${TAG_NAME}, found ${tag_type}." >&2
+            exit 1
+          fi
           gitsign verify-tag \
             --certificate-identity 'https://github.com/microsoft/edge-ai/.github/workflows/release-please.yml@refs/heads/main' \
             --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \


### PR DESCRIPTION
## Description

Fixes the release workflow so release tags are created as signed annotated Git tags and release/SBOM operations run against the intended repository context.

Closes #524

## Related Issue

Closes #524

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test update

## Implementation Details

- Create signed annotated release tags with `git tag -s` before publishing draft releases.
- Reject existing lightweight tags before tag verification.
- Verify created tags locally before continuing release asset work.
- Pass `--repo "${GITHUB_REPOSITORY}"` to GitHub CLI release and SBOM operations.
- Ignore draft releases when selecting the previous release for SBOM diffing.
- Add the Release Please skip condition used by the reference release pattern.

## Testing Performed

- [x] `git diff --check`
- [x] `actionlint` when available
- [x] Editor diagnostics
- [x] `npm run yaml` (completed with unrelated existing warnings)

## Validation Steps

1. Confirm Release Please creates or updates a draft release.
2. Confirm the workflow creates a signed annotated tag for a new release.
3. Confirm `verify-tag-signature.yml` verifies the annotated tag successfully.
4. Confirm SBOM/release asset operations target `microsoft/edge-ai` explicitly.

## Checklist

- [x] I have read the contributing guidelines
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] I have updated the documentation where necessary
- [x] My changes generate no new warnings
- [x] I have tested my changes locally
- [x] Any dependent changes have been merged and published

## Security Review

- [x] No secrets, tokens, or credentials are included
- [x] Changes preserve signed release tag verification
- [x] GitHub CLI operations use explicit repository context

## Additional Notes

This PR does not repair or recreate any existing release tags. Existing lightweight release tags will still need separate operator action if they must be verified as signed annotated tags.

## Screenshots (if applicable)

Not applicable.
