### PR TITLE
fix(release): guard release body size

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -250,7 +250,10 @@ jobs:
           OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
+          start_marker='<!-- edge-ai-release-verification:start -->'
+          end_marker='<!-- edge-ai-release-verification:end -->'
           {
+            printf '%s\n\n' "${start_marker}"
             printf '## Verification\n\n'
             printf 'Verify the signed tag:\n\n'
             printf '```sh\n'
@@ -265,13 +268,51 @@ jobs:
             printf 'gh attestation verify <artifact> --owner %s --bundle <artifact>.intoto.jsonl\n' "${OWNER}"
             printf '```\n\n'
             printf '### SBOM diff (vs previous release)\n\n'
-            printf '```diff\n'
-            cat sbom-diff/sbom-diff.txt
-            printf '```\n'
+            printf 'Full SBOM diff evidence is attached to this release as `sbom-diff.txt`.\n\n'
+            printf '%s\n' "${end_marker}"
           } > notes-appendix.md
+          gh release upload "${TAG}" sbom-diff/sbom-diff.txt \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber
           gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-            --json body --jq .body > existing-body.md || true
-          cat existing-body.md notes-appendix.md > merged-body.md
+            --json body --jq .body > existing-body.md
+          if grep -Fq "${start_marker}" existing-body.md; then
+            awk -v start="${start_marker}" -v end="${end_marker}" '
+              BEGIN { skipping = 0; inserted = 0 }
+              $0 == start {
+                while ((getline line < "notes-appendix.md") > 0) {
+                  print line
+                }
+                close("notes-appendix.md")
+                skipping = 1
+                inserted = 1
+                next
+              }
+              skipping && $0 == end { skipping = 0; next }
+              !skipping { print }
+              END {
+                if (skipping) {
+                  exit 1
+                }
+                if (!inserted) {
+                  exit 2
+                }
+              }
+            ' existing-body.md > merged-body.md
+          else
+            cat existing-body.md > merged-body.md
+            if [[ -s merged-body.md ]]; then
+              printf '\n\n' >> merged-body.md
+            fi
+            cat notes-appendix.md >> merged-body.md
+          fi
+          body_size=$(wc -m < merged-body.md | tr -d '[:space:]')
+          max_body_size=110000
+          if (( body_size > max_body_size )); then
+            printf 'Release body is %s characters, which exceeds the %s character guard.\n' \
+              "${body_size}" "${max_body_size}" >&2
+            exit 1
+          fi
           gh release edit "${TAG}" --repo "${GITHUB_REPOSITORY}" \
             --notes-file merged-body.md
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -276,7 +276,7 @@ jobs:
             --clobber
           gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
             --json body --jq .body > existing-body.md
-          if grep -Fq "${start_marker}" existing-body.md; then
+          if grep -Fxq "${start_marker}" existing-body.md; then
             awk -v start="${start_marker}" -v end="${end_marker}" '
               BEGIN { skipping = 0; inserted = 0 }
               $0 == start {


### PR DESCRIPTION
<!-- markdownlint-disable-file -->

# fix(release): guard release body size

> **IMPORTANT:** Before submitting, please remove all sensitive data, secrets, tokens, or confidential information. Ensure you've redacted any NDA-covered information, IP addresses, resource names, or security-related details that shouldn't be publicly disclosed.

## Description

Updated the Release Please workflow so large SBOM diffs are published as a release asset instead of being expanded into the release body. The verification appendix still records provenance verification guidance, but now links reviewers to `sbom-diff.txt` and applies a marker-bounded replacement path for repeated workflow runs.

The workflow also checks the merged release body size before editing the draft release. If the body exceeds the configured guard, the workflow fails before publishing the draft release.

## Related Issue

Related to #542.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Blueprint modification or addition
* [ ] Component modification or addition
* [ ] Documentation update
* [x] CI/CD pipeline change
* [ ] Other (please describe):

## Implementation Details

Changed the `append-verification-notes` job in `.github/workflows/release-please.yml` to upload the SBOM diff artifact to the draft release as `sbom-diff.txt`. The release body now receives a compact verification appendix with marker comments, provenance verification guidance, and a pointer to the attached SBOM diff evidence.

The same job retrieves the existing release body, replaces any prior marker-bounded verification block, and checks the final body length against a `110000` character guard before running `gh release edit`. The `publish-release` job now waits on `append-verification-notes` so release publication does not continue when the appendix update fails.

## Testing Performed

* [ ] Terraform plan/apply
* [ ] Blueprint deployment test
* [ ] Unit tests
* [ ] Integration tests
* [ ] Bug fix includes regression test (see [Test Policy](docs/contributing/testing-validation.md))
* [x] Manual validation
* [x] Other: whitespace validation

Manual validation compared the branch diff against `origin/main` and confirmed the change was limited to the Release Please workflow. Static functional and standards reviews found no actionable issues in the workflow diff. `git diff --check` passed. `npm run yaml -- .github/workflows/release-please.yml` could not complete because `yamllint` is not installed in the current shell.

## Validation Steps

1. Open `.github/workflows/release-please.yml`.
2. Confirm `append-verification-notes` uploads `sbom-diff/sbom-diff.txt` to the draft release as `sbom-diff.txt`.
3. Confirm the release body appendix uses the `edge-ai-release-verification` start and end markers.
4. Confirm the final release body is checked against `max_body_size=110000` before `gh release edit` runs.
5. Confirm `publish-release` depends on `append-verification-notes`.

## Checklist

* [ ] I have updated the documentation accordingly
* [ ] I have added tests to cover my changes
* [ ] All new and existing tests passed
* [ ] I have run `terraform fmt` on all Terraform code
* [ ] I have run `terraform validate` on all Terraform code
* [ ] I have run `az bicep format` on all Bicep code
* [ ] I have run `az bicep build` to validate all Bicep code
* [x] I have checked for any sensitive data/tokens that should not be committed
* [ ] Lint checks pass (run applicable linters for changed file types)

## Security Review

* [x] No credentials, secrets, or tokens are hardcoded or logged
* [x] RBAC and identity changes follow least-privilege principles
* [x] No new network exposure or public endpoints introduced without justification
* [x] Dependency additions or updates have been reviewed for known vulnerabilities
* [x] Container image changes use pinned digests or SHA references

## Additional Notes

The workflow was not executed locally because the changed path depends on GitHub Actions release context and GitHub Releases API state.

## Screenshots (if applicable)

Not applicable.
