### PR TITLE
ci: enable Go contract test gate (#562 3/4)

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,0 +1,36 @@
+---
+name: Go Tests
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  go-tests:
+    name: Go Static Contract Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: blueprints/full-single-node-cluster/tests/go.mod
+          cache-dependency-path: blueprints/full-single-node-cluster/tests/go.sum
+
+      - name: Install terraform-docs
+        shell: bash
+        run: ./scripts/install-terraform-docs.sh
+
+      - name: Install Azure CLI and Bicep
+        shell: bash
+        run: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          az bicep install
+
+      - name: Run Go static contract tests
+        run: npm run go-test

--- a/.github/workflows/matrix-folder-check.yml
+++ b/.github/workflows/matrix-folder-check.yml
@@ -29,6 +29,7 @@
 # - changesInApplications: true/false indicating if any Application folders have changed (when includeApplications=true)
 # - changedApplicationFolders: JSON object with Application folder details for matrix strategy (when includeApplications=true)
 # - changesInRust: true/false indicating if any Rust-related files have changed (gates the rust-tests workflow)
+# - changesInGoContractTests: true/false indicating if static Go contract-test files have changed (gates the go-tests workflow)
 #
 # Usage Examples:
 # ```yaml
@@ -150,6 +151,9 @@ on:  # yamllint disable-line rule:truthy
       changesInRust:
         description: 'Whether any Rust-relevant files have changed (gates rust-tests)'
         value: ${{ jobs.map-outputs.outputs.changesInRust }}
+      changesInGoContractTests:
+        description: 'Whether any static Go contract-test relevant files have changed (gates go-tests)'
+        value: ${{ jobs.map-outputs.outputs.changesInGoContractTests }}
 
 permissions: {}
 
@@ -174,6 +178,7 @@ jobs:
       changesInFuzzJs: ${{ steps.detect.outputs.changesInFuzzJs }}
       changedFuzzJsFolders: ${{ steps.detect.outputs.changedFuzzJsFolders }}
       changesInRust: ${{ steps.detect.outputs.changesInRust }}
+      changesInGoContractTests: ${{ steps.detect.outputs.changesInGoContractTests }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -233,6 +238,11 @@ jobs:
             'changedFuzzJsFolders={"folderName":[]}' >> $env:GITHUB_OUTPUT
           }
           "changesInRust=$($jsonData.rust.has_changes)" >> $env:GITHUB_OUTPUT
+          if ($jsonData.PSObject.Properties.Name -contains 'goContractTests') {
+            "changesInGoContractTests=$($jsonData.goContractTests.has_changes.ToString().ToLower())" >> $env:GITHUB_OUTPUT
+          } else {
+            "changesInGoContractTests=false" >> $env:GITHUB_OUTPUT
+          }
 
           # Display results for debugging
           Write-Host "Detection results:"
@@ -250,6 +260,11 @@ jobs:
             Write-Host "Fuzz JS changes: $($jsonData.fuzz.js.has_changes)"
           }
           Write-Host "Rust changes: $($jsonData.rust.has_changes)"
+          if ($jsonData.PSObject.Properties.Name -contains 'goContractTests') {
+            Write-Host "Go contract test changes: $($jsonData.goContractTests.has_changes)"
+          } else {
+            Write-Host "Go contract test changes: false"
+          }
 
   # Map outputs from the detection job to maintain backward compatibility
   map-outputs:
@@ -272,6 +287,7 @@ jobs:
       changesInFuzzJs: ${{ needs.detect-changes.outputs.changesInFuzzJs }}
       changedFuzzJsFolders: ${{ needs.detect-changes.outputs.changedFuzzJsFolders }}
       changesInRust: ${{ needs.detect-changes.outputs.changesInRust }}
+      changesInGoContractTests: ${{ needs.detect-changes.outputs.changesInGoContractTests }}
     steps:
       - name: Map outputs for backward compatibility
         run: echo "Mapping outputs from detection job for backward compatibility"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -251,6 +251,16 @@ jobs:
     uses: ./.github/workflows/rust-tests.yml
     secrets: inherit
 
+  # Static Go contract tests for full-single-node-cluster blueprint outputs
+  go-tests:
+    name: Go Tests
+    needs: [matrix-changes]
+    if: github.event_name != 'pull_request' || needs.matrix-changes.outputs.changesInGoContractTests == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/go-tests.yml
+    secrets: inherit
+
   # Dependency advisory audit (cargo-audit + govulncheck) for PRs
   dep-audit:
     name: Dependency Audit
@@ -406,6 +416,7 @@ jobs:
       - aio-version-check
       - rust-clippy
       - rust-tests
+      - go-tests
       - dep-audit
       - fuzz
       - matrix-changes


### PR DESCRIPTION
# Pull Request

> **IMPORTANT:** Before submitting, please remove all sensitive data, secrets, tokens, or confidential information. Ensure you've redacted any NDA-covered information, IP addresses, resource names, or security-related details that shouldn't be publicly disclosed.

## Description

PR 3 of 4 for #562 — wires the Go contract test job into PR validation as a gated, reusable workflow.

Stacked on top of #572 (PR 2 — path detector + `Invoke-GoTest` wrapper). Review/merge after #571 and #572.

## Related Issue

Closes #569
Relates to #562

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Blueprint modification or addition
- [ ] Component modification or addition
- [ ] Documentation update
- [x] CI/CD pipeline change
- [ ] Other (please describe):

## Implementation Details

- **`.github/workflows/go-tests.yml`** (new, reusable `workflow_call`):
  - Pinned action SHAs (`actions/checkout@de0fac2e…` v6.0.2, `actions/setup-go@4a360112…` v6.4.0).
  - Hermetic Go toolchain via `go-version-file: blueprints/full-single-node-cluster/tests/go.mod` and `cache-dependency-path: blueprints/full-single-node-cluster/tests/go.sum`.
  - Installs `terraform-docs` (`scripts/install-terraform-docs.sh`) and Azure CLI + `az bicep install` so the contract tests can render Terraform and Bicep deterministically.
  - Final step: `npm run go-test` — the wrapper added in PR 2.
  - Top-level `permissions: {}`; job-scoped `permissions: contents: read`.

- **`.github/workflows/matrix-folder-check.yml`**:
  - Surfaces a new `changesInGoContractTests` output through `detect-changes` → `map-outputs` → `workflow_call.outputs`.
  - PowerShell read is contract-safe: guards on `PSObject.Properties.Name -contains 'goContractTests'` and falls back to `false`, so older detector payloads keep working.
  - Adds the matching debug line in the "Detection results" display block.

- **`.github/workflows/pr-validation.yml`**:
  - New `go-tests` job calls `./.github/workflows/go-tests.yml` with `secrets: inherit`.
  - Gating: `if: github.event_name != 'pull_request' || needs.matrix-changes.outputs.changesInGoContractTests == 'true'` — always runs on non-PR events; on PRs runs only when the detector reports relevant changes.
  - Added to the `pr-validation-status` `needs` aggregation so the gate participates in required checks.

Detector / workflow contract — the new output is fed by the detector changes shipped in PR 2:

- `Detect-Folder-Changes.ps1` (line 869): `$goContractTestsHasChanges = Test-GoContractTestHasChange -ChangedFiles $changedFiles`
- Line 871: `$jsonOutput | Add-Member -MemberType NoteProperty -Name "goContractTests" -Value ([PSCustomObject]@{ has_changes = [bool]$goContractTestsHasChanges })`

`matrix-folder-check.yml` consumes that PSObject and converts it to a lowercase `true`/`false` for the `if:` expression.

## Testing Performed

- [ ] Terraform plan/apply
- [ ] Blueprint deployment test
- [x] Unit tests
- [ ] Integration tests
- [ ] Bug fix includes regression test (see [Test Policy](docs/contributing/testing-validation.md))
- [x] Manual validation
- [x] Other: end-to-end CI validation occurs naturally once this PR's `go-tests` job runs against itself.

## Validation Steps

- `yamllint .github/workflows/go-tests.yml .github/workflows/matrix-folder-check.yml .github/workflows/pr-validation.yml` → exit 0, no findings.
- `npm run lint` → no new warnings (only pre-existing baseline `document-start`, `comments-indentation`, and `node_modules` Dockerfile findings).
- Pester tests covering the detector and runner ship in PR 2 (27/0/0 + 14/0/0).
- End-to-end CI validation occurs naturally once this PR's `go-tests` job runs against itself.

## Checklist

- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] I have run `terraform fmt` on all Terraform code
- [ ] I have run `terraform validate` on all Terraform code
- [ ] I have run `az bicep format` on all Bicep code
- [ ] I have run `az bicep build` to validate all Bicep code
- [x] I have checked for any sensitive data/tokens that should not be committed
- [x] Lint checks pass (run applicable linters for changed file types)

## Security Review

- [x] No credentials, secrets, or tokens are hardcoded or logged
- [x] RBAC and identity changes follow least-privilege principles
- [x] No new network exposure or public endpoints introduced without justification
- [x] Dependency additions or updates have been reviewed for known vulnerabilities
- [x] Container image changes use pinned digests or SHA references

Workflow follows the deny-all top-level permissions baseline (`permissions: {}`) with per-job least-privilege scopes (`contents: read`). All action references are pinned to commit SHAs. This PR does not touch `SECURITY.md`, `src/000-cloud/010-security-identity/`, or `deploy/`.

## Additional Notes

Stack:

- #571 (1/4) → #572 (2/4) → **this PR (3/4)** → PR 4 (docs + cleanup of legacy shell wrappers)

## Screenshots (if applicable)

N/A.

🔒 - Generated by Copilot