### PR TITLE
fix(terraform): ignore platform-managed ForceNew attributes on public IPs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -277,7 +277,7 @@ Use these as templates when creating new components or understanding expected pa
 <!-- <terraform-operations> -->
 ## Terraform Operations Requirements
 
-* Use `npm run tf-validate` for terraform validate and `npm run tflint-fix-fast` for terraform linting with tflint
+* Use `npm run tf-validate` for terraform validate and `npm run tflint-fix-all` for terraform linting with tflint
   * Avoid running tflint immediately after adding any **unused** variables, locals, or data resources, that will eventually be used in later edits
   * tflint will remove all unused variables, locals, resources, and data resources if they have no usages
 * `terraform init`, `terraform validate`, `terraform test`, `terraform plan`, `terraform apply`, requires `source [workspaceFolder]/scripts/az-sub-init.sh` ran at least once before any `run_in_terminal` commands to set the `ARM_SUBSCRIPTION_ID` env variable for terraform

--- a/copilot/terraform/terraform-standards.md
+++ b/copilot/terraform/terraform-standards.md
@@ -83,6 +83,17 @@ You are an expert in Terraform Infrastructure as Code (IaC) with deep knowledge 
   * Never do, e.g., `depends_on = length(module.dependency_module) > 0 ? [module.dependency_module]: []`
   * Never do , e.g., `depends_on = var.should_deploy_dependency ? [module.dependency_module] : []`
 
+#### Platform-Managed Attributes and Lifecycle
+
+The Azure platform (or a customer's Azure Policy) can populate attributes on a resource after creation that are not present in the Terraform configuration. When such an attribute is ForceNew, the next `plan` treats the platform value as drift it must remove and forces replacement, which can cascade through dependent resources.
+
+* You MUST add `lifecycle { ignore_changes = [...] }` for platform-managed ForceNew attributes so the platform owns the field and the configuration stays clean
+  * Example: `azurerm_public_ip` resources MUST ignore `ip_tags`, which the platform stamps on Standard SKU public IPs and which is ForceNew
+* You MUST prefer ignoring the attribute over hardcoding a literal platform-assigned value, since the value can vary by subscription, region, or offer
+* You MUST NOT use `ignore_changes = all`, which hides legitimate drift
+* You SHOULD audit new resource types for platform-/Policy-injected ForceNew attributes whenever a replacement cascade is possible
+* For governance `tags` appended by Azure Policy (non-destructive in-place drift), handle per-resource since `azurerm` has no provider-level tag-ignore
+
 #### Resource Naming
 
 * You MUST follow [Azure naming conventions](https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming)

--- a/src/000-cloud/050-networking/terraform/modules/nat-gateway/main.tf
+++ b/src/000-cloud/050-networking/terraform/modules/nat-gateway/main.tf
@@ -28,6 +28,12 @@ resource "azurerm_public_ip" "nat" {
   allocation_method   = "Static"
   sku                 = "Standard"
   zones               = length(var.availability_zones) > 0 ? var.availability_zones : null
+
+  lifecycle {
+    // ip_tags are stamped by the Azure platform on Standard SKU public IPs and are
+    // ForceNew; the platform owns this field, so ignore it to avoid replacement.
+    ignore_changes = [ip_tags]
+  }
 }
 
 resource "azurerm_nat_gateway_public_ip_association" "main" {

--- a/src/000-cloud/051-vm-host/terraform/modules/virtual-machine/main.tf
+++ b/src/000-cloud/051-vm-host/terraform/modules/virtual-machine/main.tf
@@ -14,6 +14,12 @@ resource "azurerm_public_ip" "aio_edge" {
   allocation_method   = "Static"
   sku                 = "Standard"
   domain_name_label   = "dns-${var.label_prefix}-${var.vm_index}"
+
+  lifecycle {
+    // ip_tags are stamped by the Azure platform on Standard SKU public IPs and are
+    // ForceNew; the platform owns this field, so ignore it to avoid replacement.
+    ignore_changes = [ip_tags]
+  }
 }
 
 resource "azurerm_network_interface" "aio_edge" {

--- a/src/000-cloud/055-vpn-gateway/terraform/modules/vpn-gateway/main.tf
+++ b/src/000-cloud/055-vpn-gateway/terraform/modules/vpn-gateway/main.tf
@@ -37,6 +37,12 @@ resource "azurerm_public_ip" "vpn_gateway" {
   resource_group_name = var.resource_group.name
   allocation_method   = "Static"
   sku                 = "Standard"
+
+  lifecycle {
+    // ip_tags are stamped by the Azure platform on Standard SKU public IPs and are
+    // ForceNew; the platform owns this field, so ignore it to avoid replacement.
+    ignore_changes = [ip_tags]
+  }
 }
 
 /*

--- a/src/000-cloud/073-vm-host/terraform/modules/virtual-machine/main.tf
+++ b/src/000-cloud/073-vm-host/terraform/modules/virtual-machine/main.tf
@@ -14,6 +14,12 @@ resource "azurerm_public_ip" "aio_edge" {
   allocation_method   = "Static"
   sku                 = "Standard"
   domain_name_label   = "dns-${var.label_prefix}-${var.vm_index}"
+
+  lifecycle {
+    // ip_tags are stamped by the Azure platform on Standard SKU public IPs and are
+    // ForceNew; the platform owns this field, so ignore it to avoid replacement.
+    ignore_changes = [ip_tags]
+  }
 }
 
 resource "azurerm_network_interface" "aio_edge" {


### PR DESCRIPTION
## Description

This PR stops Terraform from forcing destructive replacements of public IPs caused by a platform-managed attribute that the modules never declare.

> The Azure platform (or a customer's Azure Policy) stamps a `ip_tags` value on Standard SKU public IPs after creation. Because the modules omit `ip_tags`, every subsequent `plan` read the platform value as drift it had to remove. Since `ip_tags` is *ForceNew*, that drift forced a full replacement of the public IP, which cascaded into dependent resources such as the Arc cluster.

The fix adds a `lifecycle { ignore_changes = [ip_tags] }` block to the four *azurerm_public_ip* resources across the cloud networking, VM host, and VPN gateway modules so the platform owns the field and the configuration stays clean. A companion section in the Terraform standards documents the convention for handling platform-managed *ForceNew* attributes going forward.

## Related Issue

Closes #606

## Type of Change
<!-- What type of change does this PR introduce? Mark relevant options with 'x' -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Blueprint modification or addition
- [x] Component modification or addition
- [x] Documentation update
- [ ] CI/CD pipeline change
- [ ] Other (please describe):

## Implementation Details
<!-- Describe the implementation details and approach taken -->

Each affected `azurerm_public_ip` resource is **Standard SKU** with `allocation_method = "Static"`, the configuration that triggers the platform to stamp `ip_tags`. The change adds an identical `lifecycle` block with an inline comment explaining that `ip_tags` is platform-stamped and *ForceNew*:

- [src/000-cloud/050-networking/terraform/modules/nat-gateway/main.tf](src/000-cloud/050-networking/terraform/modules/nat-gateway/main.tf) — `azurerm_public_ip.nat`
- [src/000-cloud/051-vm-host/terraform/modules/virtual-machine/main.tf](src/000-cloud/051-vm-host/terraform/modules/virtual-machine/main.tf) — `azurerm_public_ip.aio_edge`
- [src/000-cloud/055-vpn-gateway/terraform/modules/vpn-gateway/main.tf](src/000-cloud/055-vpn-gateway/terraform/modules/vpn-gateway/main.tf) — `azurerm_public_ip.vpn_gateway`
- [src/000-cloud/073-vm-host/terraform/modules/virtual-machine/main.tf](src/000-cloud/073-vm-host/terraform/modules/virtual-machine/main.tf) — `azurerm_public_ip.aio_edge`

The standards file [copilot/terraform/terraform-standards.md](copilot/terraform/terraform-standards.md) gained a new *Platform-Managed Attributes and Lifecycle* subsection. It establishes that platform-managed *ForceNew* attributes **MUST** be ignored via `lifecycle { ignore_changes = [...] }`, cites `azurerm_public_ip` / `ip_tags` as the canonical example, requires preferring an ignore over hardcoding a platform-assigned value (which varies by subscription, region, or offer), forbids `ignore_changes = all`, and notes that Policy-appended governance `tags` are handled per-resource because `azurerm` has no provider-level tag-ignore.

## Testing Performed
<!-- Describe the testing you have performed or plan to perform -->
<!-- For bug fixes: A regression test verifies the fix and prevents the issue from recurring -->
- [x] Terraform plan/apply
- [x] Blueprint deployment test
- [ ] Unit tests
- [ ] Integration tests
- [ ] Bug fix includes regression test (see [Test Policy](docs/contributing/testing-validation.md))
- [ ] Manual validation
- [ ] Other:

## Validation Steps
<!-- Provide steps that reviewers should follow to validate your changes -->

1. Run `npm run tf-validate` and `npm run tflint-fix-all` against the four affected module directories.
2. Deploy a blueprint that provisions a Standard SKU public IP (for example, *full-single-node-cluster*), then run `terraform plan` again and confirm the public IP is no longer marked for replacement.

## Checklist
<!-- Mark relevant options with 'x' -->
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [x] I have run `terraform fmt` on all Terraform code
- [x] I have run `terraform validate` on all Terraform code
- [ ] I have run `az bicep format` on all Bicep code
- [ ] I have run `az bicep build` to validate all Bicep code
- [x] I have checked for any sensitive data/tokens that should not be committed
- [x] Lint checks pass (run applicable linters for changed file types)

## Security Review
<!-- Required for PRs touching security-sensitive paths:
     - SECURITY.md
     - src/000-cloud/010-security-identity/
     - deploy/
     PRs modifying these paths require the `security-reviewed` label before merge. -->

- [x] No credentials, secrets, or tokens are hardcoded or logged
- [x] RBAC and identity changes follow least-privilege principles
- [x] No new network exposure or public endpoints introduced without justification
- [x] Dependency additions or updates have been reviewed for known vulnerabilities
- [x] Container image changes use pinned digests or SHA references

## Additional Notes
<!-- Add any other context about the PR here -->

The change only affects drift handling on existing public IP resources; it introduces no new network exposure and no security-sensitive paths (`SECURITY.md`, `src/000-cloud/010-security-identity/`, `deploy/`) were touched.

Also corrected a stale reference in [.github/copilot-instructions.md](.github/copilot-instructions.md): the *Terraform Operations Requirements* section pointed at a non-existent `npm run tflint-fix-fast` script. Updated it to `npm run tflint-fix-all`, which matches the actual script in *package.json* and the existing reference later in the same section.

## Screenshots (if applicable)
<!-- Add screenshots to show the changes, if applicable -->
