### PR TITLE
docs: document regression test tracking

### DIFF
--- a/docs/contributing/testing-validation.md
+++ b/docs/contributing/testing-validation.md
@@ -27,6 +27,19 @@ To maintain code quality and the OSSF Best Practices Badge, we enforce the follo
 1. **New Functionality**: All new major functionality requires corresponding automated tests.
 2. **Bug Fixes**: Bug fixes require regression tests that verify the fix.
 
+### Regression Test Tracking
+
+Bug-fix pull requests should include a regression test unless the change is documentation-only, configuration-only, or cannot be covered by a stable automated test. A regression test should reproduce the failing behavior and pass only after the fix. It can be implemented as a unit, contract, integration, deployment, or component test using the framework listed below.
+
+For tracking, bug-fix PRs should state whether a regression test is included in the validation notes. Maintainers can apply the `regression-test` label when the PR includes one. If a bug fix does not include a regression test, the PR should explain the exception so the gap can be reviewed.
+
+To measure the OSSF target that at least 50% of bug fixes include regression tests, compare merged bug-fix PRs that have the label against all merged bug-fix PRs over the review window:
+
+```text
+is:pr is:merged label:bug label:regression-test
+is:pr is:merged label:bug -label:regression-test
+```
+
 ### Technology Requirements
 
 | Technology     | Framework               | Minimum Requirement                                   |

--- a/docs/contributing/testing-validation.md
+++ b/docs/contributing/testing-validation.md
@@ -2,7 +2,7 @@
 title: Testing and Validation
 description: Comprehensive guide to testing infrastructure components and validating changes, covering testing strategies, validation procedures, and quality assurance practices
 author: Edge AI Team
-ms.date: 2025-06-06
+ms.date: 2026-06-19
 ms.topic: how-to
 estimated_reading_time: 7
 keywords:
@@ -31,13 +31,13 @@ To maintain code quality and the OSSF Best Practices Badge, we enforce the follo
 
 Bug-fix pull requests should include a regression test unless the change is documentation-only, configuration-only, or cannot be covered by a stable automated test. A regression test should reproduce the failing behavior and pass only after the fix. It can be implemented as a unit, contract, integration, deployment, or component test using the framework listed below.
 
-For tracking, bug-fix PRs should state whether a regression test is included in the validation notes. Maintainers can apply the `regression-test` label when the PR includes one. If a bug fix does not include a regression test, the PR should explain the exception so the gap can be reviewed.
+For tracking, bug-fix PRs should state whether a regression test is included in the validation notes. Maintainers can apply the `regression-test` label when the PR includes one. Bug-fix PRs should also have the `bug` label at merge time so the tracking queries return meaningful data. If a bug fix does not include a regression test, the PR should explain the exception so the gap can be reviewed.
 
 To measure the OSSF target that at least 50% of bug fixes include regression tests, compare merged bug-fix PRs that have the label against all merged bug-fix PRs over the review window:
 
 ```text
-is:pr is:merged label:bug label:regression-test
-is:pr is:merged label:bug -label:regression-test
+is:pr is:merged repo:microsoft/edge-ai label:bug label:regression-test
+is:pr is:merged repo:microsoft/edge-ai label:bug -label:regression-test
 ```
 
 ### Technology Requirements


### PR DESCRIPTION
## Description

Adds a Regression Test Tracking section to the existing Test Policy so bug-fix PRs document regression coverage consistently.

## Related Issue

Refs #176

## Type of Change

- [x] Documentation update

## Implementation Details

- Defines when bug-fix PRs should include regression tests and when exceptions should be documented.
- Documents the `regression-test` label as the tracking signal for PRs that include regression coverage.
- Adds merged-PR queries that compare labeled bug fixes against bug fixes missing the label for the 50% OSSF target.

## Testing Performed

- [x] Manual validation
- [ ] Bug fix includes regression test (not applicable; documentation-only change)

## Validation Steps

Review the rendered Markdown in `docs/contributing/testing-validation.md`.

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have checked for any sensitive data/tokens that should not be committed
