### PR TITLE
fix(deps): patch rust advisories quinn-proto and memmap2

### DIFF
--- a/src/500-application/502-rust-http-connector/services/broker/Cargo.lock
+++ b/src/500-application/502-rust-http-connector/services/broker/Cargo.lock
@@ -1426,9 +1426,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/src/500-application/507-ai-inference/services/ai-edge-inference-crate/Cargo.lock
+++ b/src/500-application/507-ai-inference/services/ai-edge-inference-crate/Cargo.lock
@@ -1467,9 +1467,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",

--- a/src/500-application/507-ai-inference/services/ai-edge-inference/Cargo.lock
+++ b/src/500-application/507-ai-inference/services/ai-edge-inference/Cargo.lock
@@ -2251,9 +2251,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
  "stable_deref_trait",


### PR DESCRIPTION
## Description

Patches two newly published Rust security advisories that are failing the `Dependency Audit` (`cargo-audit`) CI job and blocking unrelated PRs (for example #519) from merging. Both fixes are semver-compatible, lockfile-only dependency bumps with no source or behavior changes.

- **quinn-proto** `0.11.14` → `0.11.15` in `src/500-application/502-rust-http-connector/services/broker` to resolve [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185.html) — *Remote memory exhaustion from unbounded out-of-order stream reassembly* (CVSS 7.5 HIGH, denial-of-service).
- **memmap2** `0.9.10` → `0.9.11` in `src/500-application/507-ai-inference/services/ai-edge-inference` and `ai-edge-inference-crate` to resolve [RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186.html) — *Unchecked pointer offset* (unsound).

These were addressed by upgrading the affected dependencies to their patched releases rather than allow-listing them in `.github/audit.toml` / `osv-scanner.toml`, because fixed versions are available and semver-compatible.

## Related Issue

Relates to #519 (the cargo-audit failures were blocking that PR)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Blueprint modification or addition
- [ ] Component modification or addition
- [ ] Documentation update
- [ ] CI/CD pipeline change
- [ ] Other (please describe):

## Implementation Details

- Ran `cargo update -p quinn-proto --precise 0.11.15` in the `502-rust-http-connector` broker crate.
- Ran `cargo update -p memmap2 --precise 0.9.11` in both `507-ai-inference` crates.
- Only `Cargo.lock` files changed; the affected entries are transitive dependencies, so no `Cargo.toml` manifest edits were required.
- The diff is limited to the dependency version and checksum lines (6 lines across 3 lockfiles); no other dependencies were moved.

## Testing Performed

- [ ] Terraform plan/apply
- [ ] Blueprint deployment test
- [ ] Unit tests
- [ ] Integration tests
- [ ] Bug fix includes regression test (see [Test Policy](docs/contributing/testing-validation.md))
- [x] Manual validation
- [ ] Other:

Ran `cargo audit --deny warnings` (with the repo `.github/audit.toml` allow-list applied) against each affected crate; all three now report no advisories. The remaining allow-listed advisories (`instant`, `paste`, `rustls-pemfile`, `rand`) are unchanged.

## Validation Steps

1. For each affected crate, copy the allow-list: `cp .github/audit.toml <crate>/.cargo/audit.toml`.
2. Run `cargo audit --deny warnings` in:
   - `src/500-application/502-rust-http-connector/services/broker`
   - `src/500-application/507-ai-inference/services/ai-edge-inference`
   - `src/500-application/507-ai-inference/services/ai-edge-inference-crate`
3. Confirm each reports no `error:` advisories.

## Checklist

- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have run `terraform fmt` on all Terraform code
- [ ] I have run `terraform validate` on all Terraform code
- [ ] I have run `az bicep format` on all Bicep code
- [ ] I have run `az bicep build` to validate all Bicep code
- [x] I have checked for any sensitive data/tokens that should not be committed
- [x] Lint checks pass (run applicable linters for changed file types)

## Security Review

- [x] No credentials, secrets, or tokens are hardcoded or logged
- [ ] RBAC and identity changes follow least-privilege principles
- [x] No new network exposure or public endpoints introduced without justification
- [x] Dependency additions or updates have been reviewed for known vulnerabilities
- [ ] Container image changes use pinned digests or SHA references

## Additional Notes

- Terraform/Bicep checklist items are not applicable; this change touches only Rust `Cargo.lock` files.
- This change does not touch any security-sensitive paths (`SECURITY.md`, `src/000-cloud/010-security-identity/`, `deploy/`), so the `security-reviewed` label should not be required.
