### PR TITLE
ci(deps): allow-list ecdsa GHSA-wj6h-64fc-37mp in dependency review

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -97,6 +97,9 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
+          # ecdsa Minerva timing attack (P-256); no upstream fix, transitive via checkov.
+          # Re-evaluate when checkov drops the ecdsa dependency. See issue #641.
+          allow-ghsas: GHSA-wj6h-64fc-37mp
           warn-on-openssf-scorecard-level: 3
           comment-summary-in-pr: on-failure
 


### PR DESCRIPTION
## Description

The *Dependency Review* gate in the **PR Validation** workflow was failing on the open Dependabot pip-group update (#629). Its only high-severity finding was **ecdsa 0.19.2** (*GHSA-wj6h-64fc-37mp*, "Minerva timing attack on P-256"), a **new transitive dependency** introduced by the *checkov* 3.2.529 → 3.3.5 bump. The advisory has no fixed upstream version, so no dependency bump can satisfy `fail-on-severity: high`.

This change adds a narrowly-scoped `allow-ghsas` entry for that single advisory to the *Dependency Review* step in [.github/workflows/pr-validation.yml](.github/workflows/pr-validation.yml), with inline comments documenting the rationale and a pointer to re-evaluate when *checkov* drops the *ecdsa* dependency. No other workflow settings change.

## Related Issue

Fixes #641

## Type of Change
<!-- What type of change does this PR introduce? Mark relevant options with 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Blueprint modification or addition
- [ ] Component modification or addition
- [ ] Documentation update
- [x] CI/CD pipeline change
- [ ] Other (please describe):

## Implementation Details

Added `allow-ghsas: GHSA-wj6h-64fc-37mp` to the `actions/dependency-review-action` step within the `dependency-scan` job. The `fail-on-severity: high`, `warn-on-openssf-scorecard-level: 3`, and `comment-summary-in-pr: on-failure` settings are unchanged, so the gate still fails on every other high-or-higher advisory. Two preceding comments record that *ecdsa* is affected by a side-channel with no upstream fix, that it is transitive via *checkov*, and that the suppression should be revisited when that dependency is dropped.

## Testing Performed
<!-- Describe the testing you have performed or plan to perform -->
- [ ] Terraform plan/apply
- [ ] Blueprint deployment test
- [ ] Unit tests
- [ ] Integration tests
- [ ] Bug fix includes regression test (see [Test Policy](docs/contributing/testing-validation.md))
- [ ] Manual validation
- [ ] Other:

## Validation Steps

1. Re-run (or rebase) Dependabot PR #629 and confirm the **Dependency Scan** check now passes.
2. Confirm an unrelated high-severity advisory still fails the gate (no broadening of the suppression beyond *GHSA-wj6h-64fc-37mp*).

## Checklist
<!-- Mark relevant options with 'x' -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have run `terraform fmt` on all Terraform code
- [ ] I have run `terraform validate` on all Terraform code
- [ ] I have run `az bicep format` on all Bicep code
- [ ] I have run `az bicep build` to validate all Bicep code
- [x] I have checked for any sensitive data/tokens that should not be committed
- [ ] Lint checks pass (run applicable linters for changed file types)

## Security Review
<!-- Required for PRs touching security-sensitive paths:
     - SECURITY.md
     - src/000-cloud/010-security-identity/
     - deploy/
     PRs modifying these paths require the `security-reviewed` label before merge. -->

- [x] No credentials, secrets, or tokens are hardcoded or logged
- [x] RBAC and identity changes follow least-privilege principles
- [x] No new network exposure or public endpoints introduced without justification
- [x] Dependency additions or updates have been reviewed for known vulnerabilities
- [ ] Container image changes use pinned digests or SHA references

## Additional Notes

This intentionally suppresses one known advisory (*GHSA-wj6h-64fc-37mp*) because no patched *ecdsa* release exists; the python-ecdsa maintainers treat the Minerva side-channel as out of scope. The suppression mirrors the existing transitive-with-no-fix pattern documented in [osv-scanner.toml](osv-scanner.toml) (which feeds osv-scanner rather than the Dependency Review action). Re-evaluate and remove the entry once *checkov* no longer pulls in *ecdsa*.

## Screenshots (if applicable)
<!-- Add screenshots to show the changes, if applicable -->
