### PR TITLE
Also fail on Pester block/container failures (not just failed tests)

### DIFF
--- a/scripts/Invoke-Pester.ps1
+++ b/scripts/Invoke-Pester.ps1
@@ -94,16 +94,18 @@ $summary = @"
 | Total | $($result.TotalCount) |
 | Passed | $($result.PassedCount) |
 | Failed | $($result.FailedCount) |
+| Failed Blocks | $($result.FailedBlocksCount) |
+| Failed Containers | $($result.FailedContainersCount) |
 | Skipped | $($result.SkippedCount) |
 | Duration | $($result.Duration) |
 "@
 
 Write-CIStepSummary $summary
 
-Set-CIOutput -Name 'test-result' -Value $(if ($result.FailedCount -eq 0) { 'passed' } else { 'failed' })
+Set-CIOutput -Name 'test-result' -Value $(if (($result.FailedCount + $result.FailedBlocksCount + $result.FailedContainersCount) -eq 0) { 'passed' } else { 'failed' })
 Set-CIOutput -Name 'test-count' -Value $result.TotalCount.ToString()
 Set-CIOutput -Name 'fail-count' -Value $result.FailedCount.ToString()
 
-if ($CI -and $result.FailedCount -gt 0) {
+if ($CI -and ($result.FailedCount + $result.FailedBlocksCount + $result.FailedContainersCount) -gt 0) {
     exit 1
 }


### PR DESCRIPTION
> ⚠️ This PR was generated by an AI agent (GitHub Copilot CLI). Please review accordingly.

I've been seeing this commonly across Pester 5 build scripts and I'm fixing it where it looks like it could hide real failures.

In Pester 5 a run reports three independent failure counts:

- `FailedCount` — failed tests (`It`)
- `FailedBlocksCount` — failed `BeforeAll` / `AfterAll`
- `FailedContainersCount` — files that error during discovery / fail to load

Gating on only `FailedCount` means a `BeforeAll` that throws, or a test file that fails to load, leaves `FailedCount = 0` and the build passes green despite real failures. Pester itself derives the overall pass/fail from the sum of all three.

This includes all three counts in the gate, and surfaces each count (failed tests, blocks, containers) in the reported output instead of only the failed test count.
