### PR TITLE
fix(edge): inject onboarding env vars on inline cluster script delivery

### DIFF
--- a/src/100-edge/100-cncf-cluster/terraform/modules/arc-server-script-deployment/main.tf
+++ b/src/100-edge/100-cncf-cluster/terraform/modules/arc-server-script-deployment/main.tf
@@ -20,7 +20,12 @@ locals {
   }
   env_vars_string = join("\n", [for k, v in local.script_env_vars : "${k}=\"${v}\"" if v != ""])
 
-  rendered_script_to_deploy = var.should_use_script_from_secrets_for_deploy ? join("\n", [local.env_vars_string, local.deploy_script_secrets]) : var.script_content
+  // Always prepend the runtime env vars (CLIENT_ID, etc.) so identity-based onboarding works
+  // in both the inline (script_content) and Key Vault (deploy_script_secrets) delivery paths.
+  rendered_script_to_deploy = join("\n", [
+    local.env_vars_string,
+    var.should_use_script_from_secrets_for_deploy ? local.deploy_script_secrets : var.script_content,
+  ])
 }
 
 // Arc Machine Extension for Linux Arc-connected servers

--- a/src/100-edge/100-cncf-cluster/terraform/modules/vm-script-deployment/main.tf
+++ b/src/100-edge/100-cncf-cluster/terraform/modules/vm-script-deployment/main.tf
@@ -18,7 +18,12 @@ locals {
   }
   env_vars_string = join("\n", [for k, v in local.script_env_vars : "${k}=\"${v}\"" if v != ""])
 
-  rendered_script_to_deploy = var.should_use_script_from_secrets_for_deploy ? join("\n", [local.env_vars_string, local.deploy_script_secrets]) : var.script_content
+  // Always prepend the runtime env vars (CLIENT_ID, etc.) so identity-based onboarding works
+  // in both the inline (script_content) and Key Vault (deploy_script_secrets) delivery paths.
+  rendered_script_to_deploy = join("\n", [
+    local.env_vars_string,
+    var.should_use_script_from_secrets_for_deploy ? local.deploy_script_secrets : var.script_content,
+  ])
 }
 
 // VM Extension for Linux VMs


### PR DESCRIPTION
## Description

Fixes a defect where the `100-cncf-cluster` component's **inline** script delivery path (`should_use_script_from_secrets_for_deploy = false`) never injected the `CLIENT_ID` runtime environment variable into the CustomScript extension. The rendered onboarding script (`ubuntu-k3s`) expects `CLIENT_ID` as a runtime env var (`CLIENT_ID="${CLIENT_ID}"`), but `local.env_vars_string` was only prepended on the Key Vault path. With it empty, the on-VM script logged in with the VM's **system-assigned** managed identity (no subscription RBAC) instead of the user-assigned Arc onboarding identity, and `az connectedk8s connect` failed with `SubscriptionNotFound`.

## Related Issue

Fixes #685

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Component modification or addition

## Implementation Details

In both `vm-script-deployment/main.tf` and `arc-server-script-deployment/main.tf`, always prepend `local.env_vars_string` and select only the payload by delivery mode:

```hcl
rendered_script_to_deploy = join("\n", [
  local.env_vars_string,
  var.should_use_script_from_secrets_for_deploy ? local.deploy_script_secrets : var.script_content,
])
```

`env_vars_string` already filters out empty values, so nothing spurious is added. The Key Vault path is unchanged; the inline path now receives `CLIENT_ID` (and the other runtime vars).

## Testing Performed

- [x] Terraform plan/apply (`terraform validate` on the cncf component — *Success! The configuration is valid.*)
- [x] Manual validation (reproduced the `SubscriptionNotFound` failure on the inline path prior to the change)

## Validation Steps

1. Deploy the `full-multi-node-cluster` blueprint (VM-based) with `should_upload_to_key_vault = false` and `should_use_script_from_secrets_for_deploy = false`.
2. Before this fix: the `linux-cluster-server-setup` extension fails with "Logging in with default managed identity" → `SubscriptionNotFound`.
3. After this fix: `CLIENT_ID` is present, `az login --identity --username $CLIENT_ID` uses the onboarding identity, and Arc connect succeeds.

## Checklist

- [x] I have run `terraform fmt` / `terraform validate`
- [x] I have checked for any sensitive data/tokens that should not be committed

## Security Review

No change to identity, RBAC, or network posture. The onboarding identity's client ID is not a secret and was already passed to the Key Vault delivery path; this change makes the inline path consistent. No security-sensitive paths (`SECURITY.md`, `010-security-identity`, `deploy/`) are modified.

## Additional Notes

This is a component-level companion to the blueprint variable exposure in #683 (which made `should_use_script_from_secrets_for_deploy = false` reachable). With this fix, the inline delivery path is actually functional for identity-based onboarding.
