### PR TITLE
Fix security workflow IaC type fallback

### DIFF
--- a/.github/workflows/security-comprehensive.yml
+++ b/.github/workflows/security-comprehensive.yml
@@ -261,7 +261,7 @@ jobs:
         id: aio-check
         run: |
           python scripts/aio-version-checker.py \
-            --iac-type ${{ inputs.iac-types }} \
+            --iac-type ${{ inputs.iac-types || 'all' }} \
             --error-on-mismatch \
             --verbose
 

--- a/.github/workflows/security-deployment.yml
+++ b/.github/workflows/security-deployment.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Run AIO version check
         run: |
           python scripts/aio-version-checker.py \
-            --iac-type ${{ inputs.iac-types }} \
+            --iac-type ${{ inputs.iac-types || 'all' }} \
             --error-on-mismatch \
             --verbose
 


### PR DESCRIPTION
# Pull Request

## Description
This fixes the reusable security workflows so they pass `all` as the default IaC type when callers omit `iac-types`.

Without the fallback, an empty input can leave `--iac-type` without a value and cause the next flag to be consumed incorrectly.

## Related Issue
Closes #99.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Blueprint modification or addition
- [ ] Component modification or addition
- [ ] Documentation update
- [x] CI/CD pipeline change
- [ ] Other (please describe):

## Implementation Details
Both reusable security workflows now use the same `iac-types` fallback before invoking `scripts/aio-version-checker.py`.

## Testing Performed
- [ ] Terraform plan/apply
- [ ] Blueprint deployment test
- [ ] Unit tests
- [ ] Integration tests
- [ ] Bug fix includes regression test (see [Test Policy](docs/contributing/testing-validation.md))
- [x] Manual validation
- [x] Other:

Verified with:
- `git diff --check`
- Ruby YAML parse for `.github/workflows/security-comprehensive.yml` and `.github/workflows/security-deployment.yml`
- argparse check that `--iac-type` without a value fails, while `--iac-type all --error-on-mismatch --verbose` parses
- GitHub PR Validation checks are green

## Validation Steps
Review the two changed workflow calls and confirm the `iac-types` expression falls back to `all` before `--error-on-mismatch`.

## Checklist
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have run `terraform fmt` on all Terraform code
- [ ] I have run `terraform validate` on all Terraform code
- [ ] I have run `az bicep format` on all Bicep code
- [ ] I have run `az bicep build` to validate all Bicep code
- [x] I have checked for any sensitive data/tokens that should not be committed
- [x] Lint checks pass (run applicable linters for changed file types)

## Security Review
- [x] No credentials, secrets, or tokens are hardcoded or logged
- [ ] RBAC and identity changes follow least-privilege principles
- [x] No new network exposure or public endpoints introduced without justification
- [ ] Dependency additions or updates have been reviewed for known vulnerabilities
- [ ] Container image changes use pinned digests or SHA references

## Additional Notes
No runtime behavior changes outside the two reusable security workflow invocations.

## Screenshots (if applicable)
Not applicable.
