### PR TITLE
build: bump pinned Azure CLI 2.67.0 to 2.88.0

### DIFF
--- a/.github/workflows/bicep-lint.yml
+++ b/.github/workflows/bicep-lint.yml
@@ -64,7 +64,7 @@ jobs:
           if ! command -v az &>/dev/null; then
             echo "Azure CLI is not installed. Installing now..."
             # Pin Azure CLI install via Microsoft apt keyring/repo and explicit version (OSSF Scorecard pinned-dependencies)
-            AZ_CLI_INSTALL_VER="${AZ_CLI_VER:-2.67.0}"
+            AZ_CLI_INSTALL_VER="${AZ_CLI_VER:-2.88.0}"
             sudo apt-get update
             sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
             sudo mkdir -p /etc/apt/keyrings

--- a/.github/workflows/docs-check-bicep.yml
+++ b/.github/workflows/docs-check-bicep.yml
@@ -75,7 +75,7 @@ jobs:
           if ! command -v az &>/dev/null; then
             echo "Azure CLI is not installed. Installing now..."
             # Pin Azure CLI install via Microsoft apt keyring/repo and explicit version (OSSF Scorecard pinned-dependencies)
-            AZ_CLI_INSTALL_VER="${AZ_CLI_VER:-2.67.0}"
+            AZ_CLI_INSTALL_VER="${AZ_CLI_VER:-2.88.0}"
             sudo apt-get update
             sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
             sudo mkdir -p /etc/apt/keyrings

--- a/src/100-edge/100-cncf-cluster/scripts/deploy-script-secrets.sh
+++ b/src/100-edge/100-cncf-cluster/scripts/deploy-script-secrets.sh
@@ -98,7 +98,7 @@ if ! command -v "az" &>/dev/null; then
     case "$OS_TYPE" in
       ubuntu)
         # Pin Azure CLI install via Microsoft apt keyring/repo and explicit version (OSSF Scorecard pinned-dependencies)
-        AZ_CLI_INSTALL_VER="${AZ_CLI_VER:-2.67.0}"
+        AZ_CLI_INSTALL_VER="${AZ_CLI_VER:-2.88.0}"
         sudo apt-get update
         sudo apt-get install -y ca-certificates curl apt-transport-https lsb-release gnupg
         sudo mkdir -p /etc/apt/keyrings


### PR DESCRIPTION
## Description

Bumped the pinned default **Azure CLI** version from *2.67.0* to *2.88.0* wherever the CLI is installed with an explicit version pin. The pin lives in a shell fallback expression (`AZ_CLI_VER:-2.67.0`), so the default was raised while the `AZ_CLI_VER` environment-variable override remains intact.

> Azure CLI *2.67.0* does not accept `az login --identity --client-id <id>` for user-assigned managed identity sign-in, producing `unrecognized arguments: --client-id`. Pinning to *2.88.0* keeps the installed CLI current and compatible.

## Related Issue

Fixes #706

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Blueprint modification or addition
- [ ] Component modification or addition
- [ ] Documentation update
- [x] CI/CD pipeline change
- [x] Other (please describe): Pinned dependency version bump

## Implementation Details

Updated the single pinned-version line in each of the following files, changing only the fallback default in `AZ_CLI_INSTALL_VER="${AZ_CLI_VER:-2.67.0}"`:

- **.github/workflows/bicep-lint.yml** — Azure CLI install step
- **.github/workflows/docs-check-bicep.yml** — Azure CLI install step
- **src/100-edge/100-cncf-cluster/scripts/deploy-script-secrets.sh** — CNCF cluster onboarding CLI install

No surrounding logic changed. Callers can still pin a different version by exporting `AZ_CLI_VER`.

## Testing Performed

- [ ] Terraform plan/apply
- [ ] Blueprint deployment test
- [ ] Unit tests
- [ ] Integration tests
- [ ] Bug fix includes regression test (see [Test Policy](docs/contributing/testing-validation.md))
- [x] Manual validation
- [ ] Other:

Manually verified the diff is limited to the three pinned-version lines and that the `AZ_CLI_VER` override expression is preserved.

## Validation Steps

1. Confirm each changed file pins `AZ_CLI_VER` default to `2.88.0`:
   `git grep -n 'AZ_CLI_VER:-2.88.0'`
2. Confirm no `2.67.0` pin remains in the changed files:
   `git grep -n 'AZ_CLI_VER:-2.67.0'`

## Checklist

- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have run `terraform fmt` on all Terraform code
- [ ] I have run `terraform validate` on all Terraform code
- [ ] I have run `az bicep format` on all Bicep code
- [ ] I have run `az bicep build` to validate all Bicep code
- [x] I have checked for any sensitive data/tokens that should not be committed
- [ ] Lint checks pass (run applicable linters for changed file types)

## Security Review

- [x] No credentials, secrets, or tokens are hardcoded or logged
- [ ] RBAC and identity changes follow least-privilege principles
- [ ] No new network exposure or public endpoints introduced without justification
- [x] Dependency additions or updates have been reviewed for known vulnerabilities
- [ ] Container image changes use pinned digests or SHA references

## Additional Notes

This change only affects the default when `AZ_CLI_VER` is unset. Terraform and Bicep validation checkboxes are left unchecked because no Terraform or Bicep source was modified.
