### PR TITLE
Configure devcontainer Dockerfile with proxy/package index build args

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=
+FROM ${BASE_IMAGE:-mcr.microsoft.com/devcontainers/python:3.12-bookworm}
+
+ARG NPM_CONFIG_REGISTRY=
+ENV NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org/}
+
+ARG PIP_INDEX_URL=
+ENV PIP_INDEX_URL=${PIP_INDEX_URL:-https://pypi.org/simple/}
+
+ARG UV_DEFAULT_INDEX=
+ENV UV_DEFAULT_INDEX=${UV_DEFAULT_INDEX:-https://pypi.org/simple/}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,15 @@
 {
   "name": "edge-ai-devcontainer",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "BASE_IMAGE": "${localEnv:EDGE_AI_DEVCONTAINER_IMAGE}",
+      "NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}",
+      "PIP_INDEX_URL": "${localEnv:PIP_INDEX_URL}",
+      "UV_DEFAULT_INDEX": "${localEnv:UV_DEFAULT_INDEX}"
+    }
+  },
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {},


### PR DESCRIPTION
## Summary

Switches the dev container from a plain `image` reference to a `build` configuration backed by a new `.devcontainer/Dockerfile`. This lets the base image and package index/registry URLs be overridden via local environment variables, which is needed for environments behind a proxy or using internal package mirrors.

## Changes

- **`.devcontainer/Dockerfile`** (new): Defines build args with sensible public defaults:
  - `BASE_IMAGE` → defaults to `mcr.microsoft.com/devcontainers/python:3.12-bookworm`
  - `NPM_CONFIG_REGISTRY` → defaults to `https://registry.npmjs.org/`
  - `PIP_INDEX_URL` → defaults to `https://pypi.org/simple/`
  - `UV_DEFAULT_INDEX` → defaults to `https://pypi.org/simple/`
- **`.devcontainer/devcontainer.json`**: Replaces the static `image` with a `build` block that passes these args from `localEnv` overrides.

## Why

Contributors on proxied networks or internal mirrors can point the dev container at the correct base image and package indexes without editing tracked files. When the environment variables are unset, the defaults preserve the previous public behavior.