### PR TITLE
chore(build): isolate Checkov 3.3.16 upgrade

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ python-hcl2~=8.1.2               # HCL2 (Terraform) configuration parser
 jinja2~=3.1.6                    # Template engine for configuration generation
 
 # Security and Compliance Scanning
-checkov~=3.2.528                 # Infrastructure security and compliance scanner
+checkov~=3.3.16                 # Infrastructure security and compliance scanner
 aiohttp>=3.14.3                  # Async HTTP client used by checkov
 
 # Security-Critical Dependencies (Version Pinned for CVE Remediation)

--- a/requirements.txt
+++ b/requirements.txt
@@ -164,9 +164,9 @@ attrs==26.1.0 \
     #   aiohttp
     #   jsonschema
     #   referencing
-bc-detect-secrets==1.5.47 \
-    --hash=sha256:46f88c710b0fd8c5f2e54b361d793b5e1469197884da73cfc6f488b614366fc3 \
-    --hash=sha256:a9be28a2e564f2b19731991df39e63ae6372cc84d828ee24e50c094cbb4c154c
+bc-detect-secrets==1.5.50 \
+    --hash=sha256:016ce9e79f692adbabcbef4a7293db427352911c3f81404a136e6f5c3e54a7f2 \
+    --hash=sha256:99037375d9cb49ed07e5bb12722f4bbb76fb8acaff6f367eef9df7559e7642b3
     # via checkov
 bc-jsonpath-ng==1.6.1 \
     --hash=sha256:2c85bb1d194376808fe1fc49558dd484e39024b15c719995e22de811e6ba4dc8 \
@@ -432,9 +432,9 @@ charset-normalizer==3.4.7 \
     # via
     #   checkov
     #   requests
-checkov==3.2.531 \
-    --hash=sha256:656b035d378f5ca26457c36cf3f9b8d0fe0cc60d3d2f8ad96676d5305946be84 \
-    --hash=sha256:869ce2a4ca2f8eb540f57e95209ca9536c4420d24aa9367dfe24c22ec4dd7328
+checkov==3.3.16 \
+    --hash=sha256:43e5383418a8b52d39747e2daaec4da4a6b7db3e2f64ab6c93f8b89c044c7665 \
+    --hash=sha256:6f7f611f45c765af9b6acd43e603a438153d86007d02dffa7903a1125f9b5089
     # via -r requirements.in
 click==8.3.2 \
     --hash=sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5 \
@@ -488,6 +488,10 @@ dockerfile-parse==2.0.1 \
 dpath==2.1.3 \
     --hash=sha256:d1a7a0e6427d0a4156c792c82caf1f0109603f68ace792e36ca4596fd2cb8d9d \
     --hash=sha256:d9560e03ccd83b3c6f29988b0162ce9b34fd28b9d8dbda46663b20c68d9cdae3
+    # via checkov
+ecdsa==0.19.2 \
+    --hash=sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930 \
+    --hash=sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399
     # via checkov
 frozenlist==1.8.0 \
     --hash=sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686 \
@@ -1820,6 +1824,7 @@ six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
     # via
+    #   ecdsa
     #   junit-xml
     #   python-dateutil
 smmap==5.0.3 \


### PR DESCRIPTION
# Pull Request

> **IMPORTANT:** This is a draft, not a merge-ready dependency update. The newly introduced ecdsa dependency is affected by GHSA-wj6h-64fc-37mp / CVE-2024-23342. No security exception has been added.

## Description

Isolated the Checkov upgrade from #794 so the other four Python dependency updates can proceed independently. Updated Checkov from locked version 3.2.531 to 3.3.16, bc-detect-secrets from 1.5.47 to 1.5.50, and added Checkov's ecdsa 0.19.2 dependency.

## Related Issue

Relates to #794. No separate issue is linked.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Blueprint modification or addition
- [ ] Component modification or addition
- [ ] Documentation update
- [ ] CI/CD pipeline change
- [x] Other (please describe): isolated security-scanner dependency update

## Implementation Details

Changed only root requirements.in and requirements.txt. Retained the existing dependency hashes from the original reviewed Checkov update. Left GitPython, python-hcl2, NumPy, dotenv and all ROS2 requirements unchanged relative to main.

The inspected Checkov consumer performs public-key signature verification, which the advisory explicitly excludes. Exploitable signing behavior has not been demonstrated. The dependency nevertheless fails the repository's security policy; this draft tracks the update without suppressing that policy.

## Testing Performed

- [ ] Terraform plan/apply
- [ ] Blueprint deployment test
- [ ] Unit tests
- [ ] Integration tests
- [ ] Bug fix includes regression test (see [Test Policy](docs/contributing/testing-validation.md))
- [x] Manual validation
- [x] Other: Linux x86_64 / Python 3.12 constrained dependency resolution succeeded for 97 packages; git diff --check passed

The original grouped update's package hashes, hash-enforced installation, dependency consistency and Checkov startup were reviewed previously. The independent branch was checked for resolution and exact scope; its security gate is expected to reject ecdsa. No deployment or cloud integration test was run.

## Validation Steps

1. Confirm the diff contains only Checkov and its two affected transitive dependencies.
2. Resolve the ecdsa policy blocker through an upstream dependency change. Keep this draft blocked until the advisory is remediated; no exception is proposed.
3. Require passing Dependency Scan, Security Scan and PR Validation Gate on the final head before marking ready or merging.

## Checklist

- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] I have run terraform fmt on all Terraform code
- [ ] I have run terraform validate on all Terraform code
- [ ] I have run az bicep format on all Bicep code
- [ ] I have run az bicep build to validate all Bicep code
- [x] I have checked for any sensitive data/tokens that should not be committed
- [ ] Lint checks pass (run applicable linters for changed file types)

## Security Review

- [x] No credentials, secrets, or tokens are hardcoded or logged
- [ ] RBAC and identity changes follow least-privilege principles
- [x] No new network exposure or public endpoints introduced without justification
- [x] Dependency additions or updates have been reviewed for known vulnerabilities
- [ ] Container image changes use pinned digests or SHA references

Known blocking advisory: [GHSA-wj6h-64fc-37mp](https://github.com/advisories/GHSA-wj6h-64fc-37mp). The checked dependency-review item means the advisory was examined, not that it was accepted or remediated.

## Additional Notes

Keep this PR in draft. #794 retains GitPython 3.1.61, python-hcl2 8.1.3, NumPy 2.5.2 and python-dotenv 1.2.3 without this Checkov upgrade. No merge is requested for the Checkov-only draft.

## Screenshots (if applicable)

Not applicable.